### PR TITLE
Fix incompatible declaration in navwalker

### DIFF
--- a/includes/bootstrap-wp-navwalker.php
+++ b/includes/bootstrap-wp-navwalker.php
@@ -19,7 +19,7 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 	 * @param string $output Passed by reference. Used to append additional content.
 	 * @param int $depth Depth of page. Used for padding.
 	 */
-	function start_lvl( &$output, $depth ) {
+	function start_lvl( &$output, $depth = 0, $args = array() ) {
 
 		$indent = str_repeat( "\t", $depth );
 		if($depth == 0){


### PR DESCRIPTION
Got this error when I switched over to php 5.5.

```
Strict Standards: Declaration of wp_bootstrap_navwalker::start_lvl() should be compatible with Walker_Nav_Menu::start_lvl(&$output, $depth = 0, $args = Array) in bootstrap-wp-navwalker.php on line 150
```
