### PR TITLE
Fix issue with "collapsed" class not being added to mobile menu

### DIFF
--- a/header.php
+++ b/header.php
@@ -56,7 +56,7 @@
 				<div class="navbar navbar-default">
 					<div class="navbar-header">
 						<!-- .navbar-toggle is used as the toggle for collapsed navbar content -->
-						<button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+						<button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-collapse">
 							<span class="sr-only"><?php _e('Toggle navigation','_tk') ?> </span>
 							<span class="icon-bar"></span>
 							<span class="icon-bar"></span>
@@ -73,6 +73,7 @@
 							'theme_location' 	=> 'primary',
 							'depth'             => 2,
 							'container'         => 'div',
+							'container_id'      => 'navbar-collapse'
 							'container_class'   => 'collapse navbar-collapse',
 							'menu_class' 		=> 'nav navbar-nav',
 							'fallback_cb' 		=> 'wp_bootstrap_navwalker::fallback',


### PR DESCRIPTION
Bootstrap will add a "collapsed" class to the navbar-toggle, but only if the data-target is an ID and not a class.