### PR TITLE
Strip tags from links title attribute

### DIFF
--- a/includes/bootstrap-wp-navwalker.php
+++ b/includes/bootstrap-wp-navwalker.php
@@ -76,7 +76,7 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 			$output .= $indent . '<li' . $id . $value . $class_names .'>';
 
 			$atts = array();
-			$atts['title']  = ! empty( $item->title )	? $item->title	: '';
+			$atts['title']  = ! empty( $item->title )	? strip_tags($item->title) : '';
 			$atts['target'] = ! empty( $item->target )	? $item->target	: '';
 			$atts['rel']    = ! empty( $item->xfn )		? $item->xfn	: '';
 


### PR DESCRIPTION
Added strip_tags() to remove any tags from the title link attributes. This prevents any problems when custom HTML code is placed on the menu item's label.