### PR TITLE
Target the search widget specifically

### DIFF
--- a/includes/js/bootstrap-wp.js
+++ b/includes/js/bootstrap-wp.js
@@ -10,8 +10,8 @@ jQuery( document ).ready( function( $ ) {
     // Now we'll add some classes for the wordpress default widgets - let's go
 
     // the search widget
-    $( 'input.search-field' ).addClass( 'form-control' );
-    $( 'input.search-submit' ).addClass( 'btn btn-default' );
+    $( '.widget_search input.search-field' ).addClass( 'form-control' );
+    $( '.widget_search input.search-submit' ).addClass( 'btn btn-default' );
 
     $( '.widget_rss ul' ).addClass( 'media-list' );
 


### PR DESCRIPTION
This will also target the search inputs in searchform.php, where it's not necessary because we can modify the template ourselves.  You may want to add the `form-control` and `btn btn-default` classes to that file as defaults.
