### PR TITLE
wp_nav_menu's container changed from div to nav for more semantic html

### DIFF
--- a/header.php
+++ b/header.php
@@ -72,7 +72,7 @@
 						array(
 							'theme_location' 	=> 'primary',
 							'depth'             => 2,
-							'container'         => 'div',
+							'container'         => 'nav',
 							'container_id'      => 'navbar-collapse',
 							'container_class'   => 'collapse navbar-collapse',
 							'menu_class' 		=> 'nav navbar-nav',


### PR DESCRIPTION
> The nav element represents a section of a page that links to other pages or to parts within the page: a section with navigation links. Not all groups of links on a page need to be in a nav element only sections that consist of major navigation blocks are appropriate for the nav element. In particular, it is common for footers to have a list of links to various key parts of a site, but the footer element is more appropriate in such cases, and no nav element is necessary for those links.

It won't mess with Boostrap either by making the container element **nav** instead of **div**. There's nothing to lose with this update, only to gain (from better semantics).